### PR TITLE
display the research prerequisites in nei

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile 'curse.maven:thaumcraft-nei-plugin-225095:2241913'
 
     compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'curse.maven:automagy-222153:2285272'
 
     runtime 'com.github.GTNewHorizons:Baubles:1.0.1.14:dev'
 }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/TCNEIAdditions.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/TCNEIAdditions.java
@@ -20,7 +20,7 @@ public class TCNEIAdditions {
     public static final String NAME = "Thaumcraft NEI Additions";
     public static final String VERSION = "GRADLETOKEN_VERSION";
     public static final String DEPENDENCIES =
-            "required-after:Thaumcraft;required-after:thaumcraftneiplugin;required-after:spongemixins@[1.2.0,);";
+            "required-after:Thaumcraft;required-after:thaumcraftneiplugin;required-after:spongemixins@[1.2.0,);after:Automagy";
     public static final String GUI_FACTORY = "ru.timeconqueror.tcneiadditions.client.gui.GuiFactory";
 
     public static final Logger LOGGER = LogManager.getLogger(NAME);

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
@@ -134,12 +134,14 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
 
     @Override
     public List<String> handleTooltip(GuiRecipe gui, List<String> list, int recipeIndex) {
-        if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
-            CrucibleCachedRecipe recipe = (CrucibleCachedRecipe) arecipes.get(recipeIndex);
-            Rectangle rectangle = getResearchRect(gui, recipeIndex);
-            Point mousePos = GuiDraw.getMousePosition();
-            if (rectangle.contains(mousePos.x, mousePos.y)) {
-                TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+        if (TCNAConfig.showResearchKey) {
+            if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
+                CrucibleCachedRecipe recipe = (CrucibleCachedRecipe) arecipes.get(recipeIndex);
+                Rectangle rectangle = getResearchRect(gui, recipeIndex);
+                Point mousePos = GuiDraw.getMousePosition();
+                if (rectangle.contains(mousePos.x, mousePos.y)) {
+                    TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+                }
             }
         }
         return super.handleTooltip(gui, list, recipeIndex);

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
@@ -139,7 +139,7 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
                 CrucibleCachedRecipe recipe = (CrucibleCachedRecipe) arecipes.get(recipeIndex);
                 Rectangle rectangle = getResearchRect(gui, recipeIndex);
                 Point mousePos = GuiDraw.getMousePosition();
-                if (rectangle.contains(mousePos.x, mousePos.y)) {
+                if (rectangle.contains(mousePos)) {
                     TCUtil.getResearchPrerequisites(list, recipe.researchItem);
                 }
             }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -187,7 +187,7 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
                 InfusionCachedRecipe recipe = (InfusionCachedRecipe) arecipes.get(recipeIndex);
                 Rectangle rectangle = getResearchRect(gui, recipeIndex);
                 Point mousePos = GuiDraw.getMousePosition();
-                if (rectangle.contains(mousePos.x, mousePos.y)) {
+                if (rectangle.contains(mousePos)) {
                     TCUtil.getResearchPrerequisites(list, recipe.researchItem);
                 }
             }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -182,12 +182,14 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
 
     @Override
     public List<String> handleTooltip(GuiRecipe gui, List<String> list, int recipeIndex) {
-        if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
-            InfusionCachedRecipe recipe = (InfusionCachedRecipe) arecipes.get(recipeIndex);
-            Rectangle rectangle = getResearchRect(gui, recipeIndex);
-            Point mousePos = GuiDraw.getMousePosition();
-            if (rectangle.contains(mousePos.x, mousePos.y)) {
-                TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+        if (TCNAConfig.showResearchKey) {
+            if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
+                InfusionCachedRecipe recipe = (InfusionCachedRecipe) arecipes.get(recipeIndex);
+                Rectangle rectangle = getResearchRect(gui, recipeIndex);
+                Point mousePos = GuiDraw.getMousePosition();
+                if (rectangle.contains(mousePos.x, mousePos.y)) {
+                    TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+                }
             }
         }
         return super.handleTooltip(gui, list, recipeIndex);

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -2,6 +2,8 @@ package ru.timeconqueror.tcneiadditions.nei;
 
 import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.PositionedStack;
+import codechicken.nei.guihook.GuiContainerManager;
+import codechicken.nei.recipe.GuiRecipe;
 import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import com.djgiannuzz.thaumcraftneiplugin.items.ItemAspect;
 import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.InfusionRecipeHandler;
@@ -18,16 +20,20 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
+import ru.timeconqueror.tcneiadditions.util.GuiRecipeHelper;
 import ru.timeconqueror.tcneiadditions.util.TCNAConfig;
 import ru.timeconqueror.tcneiadditions.util.TCUtil;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
 import thaumcraft.client.lib.UtilsFX;
 
 public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
+    private int ySize;
 
     @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
@@ -116,8 +122,18 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
 
         if (TCNAConfig.showResearchKey) {
             int y = 170;
-            String textToDraw = I18n.format("tcneiadditions.research.researchKey", recipe.researchKey);
-            for (Object text : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(textToDraw, 162)) {
+            String researchString = recipe.researchItem != null
+                    ? EnumChatFormatting.UNDERLINE
+                            + ResearchCategories.getCategoryName(recipe.researchItem.category) + " : "
+                            + recipe.researchItem.getName()
+                    : EnumChatFormatting.ITALIC + "null";
+            List listResearchString =
+                    Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(researchString, 162);
+            this.ySize = listResearchString.size() * 11;
+            List<Object> list = new ArrayList<>();
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.researchName") + ":");
+            list.addAll(listResearchString);
+            for (Object text : list) {
                 GuiDraw.drawStringC((String) text, 82, y, Color.BLACK.getRGB(), false);
                 y += 11;
             }
@@ -164,13 +180,35 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
         }
     }
 
+    @Override
+    public List<String> handleTooltip(GuiRecipe gui, List<String> list, int recipeIndex) {
+        if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
+            InfusionCachedRecipe recipe = (InfusionCachedRecipe) arecipes.get(recipeIndex);
+            Rectangle rectangle = getResearchRect(gui, recipeIndex);
+            Point mousePos = GuiDraw.getMousePosition();
+            if (rectangle.contains(mousePos.x, mousePos.y)) {
+                TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+            }
+        }
+        return super.handleTooltip(gui, list, recipeIndex);
+    }
+
+    protected Rectangle getResearchRect(GuiRecipe gui, int recipeIndex) {
+        Point offset = gui.getRecipePosition(recipeIndex);
+        return new Rectangle(
+                GuiRecipeHelper.getGuiLeft(gui) + offset.x + 2,
+                GuiRecipeHelper.getGuiTop(gui) + offset.y + 181,
+                GuiRecipeHelper.getXSize(gui) - 9,
+                this.ySize);
+    }
+
     private class InfusionCachedRecipe extends CachedRecipe {
         private final AspectList aspects;
         private PositionedStack result;
         private List<PositionedStack> ingredients;
         private int instability;
         private final boolean shouldShowRecipe;
-        private final String researchKey;
+        private final ResearchItem researchItem;
 
         public InfusionCachedRecipe(InfusionRecipe recipe, boolean shouldShowRecipe) {
             this.setIngredients(recipe);
@@ -179,7 +217,7 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
             this.setInstability(recipe.getInstability());
             this.shouldShowRecipe = shouldShowRecipe;
             this.addAspectsToIngredients(this.aspects);
-            this.researchKey = recipe.getResearch() != null ? recipe.getResearch() : EnumChatFormatting.ITALIC + "null";
+            this.researchItem = ResearchCategories.getResearch(recipe.getResearch());
         }
 
         protected void setInstability(int inst) {

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
@@ -392,6 +392,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
         }
     }
 
+    @Override
     public List<String> handleTooltip(GuiRecipe gui, List<String> list, int recipeIndex) {
         if (TCNAConfig.showResearchKey) {
             if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
@@ -406,16 +407,16 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
                     ResearchItem researchItemCap = ResearchCategories.getResearch(cap.getResearch());
                     Rectangle rectangleRod = getResearchRodRect(gui, recipeIndex);
                     Rectangle rectangleCap = getResearchCapRect(gui, recipeIndex);
-                    if (rectangleRod.contains(mousePos.x, mousePos.y)) {
+                    if (rectangleRod.contains(mousePos)) {
                         TCUtil.getResearchPrerequisites(list, researchItemRod);
                     }
-                    if (rectangleCap.contains(mousePos.x, mousePos.y)) {
+                    if (rectangleCap.contains(mousePos)) {
                         TCUtil.getResearchPrerequisites(list, researchItemCap);
                     }
                 } else if (cRecipe instanceof ArcaneShapedCachedRecipe) {
                     ArcaneShapedCachedRecipe recipe = (ArcaneShapedCachedRecipe) cRecipe;
                     Rectangle rectangle = getResearchNormalRect(gui, recipeIndex);
-                    if (rectangle.contains(mousePos.x, mousePos.y)) {
+                    if (rectangle.contains(mousePos)) {
                         TCUtil.getResearchPrerequisites(list, recipe.researchItem);
                     }
                 }
@@ -446,7 +447,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
         Point offset = gui.getRecipePosition(recipeIndex);
         return new Rectangle(
                 GuiRecipeHelper.getGuiLeft(gui) + offset.x + 2,
-                GuiRecipeHelper.getGuiTop(gui) + offset.y + 157 + 11 * ySizeRod,
+                GuiRecipeHelper.getGuiTop(gui) + offset.y + 157 + ySizeRod,
                 GuiRecipeHelper.getXSize(gui) - 9,
                 this.ySizeCap);
     }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
@@ -393,29 +393,31 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
     }
 
     public List<String> handleTooltip(GuiRecipe gui, List<String> list, int recipeIndex) {
-        if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
-            CachedRecipe cRecipe = arecipes.get(recipeIndex);
-            ItemStack result = cRecipe.getResult().item;
-            Point mousePos = GuiDraw.getMousePosition();
-            if (result.getItem() instanceof ItemWandCasting) {
-                ItemWandCasting wand = (ItemWandCasting) result.getItem();
-                WandRod rod = wand.getRod(result);
-                WandCap cap = wand.getCap(result);
-                ResearchItem researchItemRod = ResearchCategories.getResearch(rod.getResearch());
-                ResearchItem researchItemCap = ResearchCategories.getResearch(cap.getResearch());
-                Rectangle rectangleRod = getResearchRodRect(gui, recipeIndex);
-                Rectangle rectangleCap = getResearchCapRect(gui, recipeIndex);
-                if (rectangleRod.contains(mousePos.x, mousePos.y)) {
-                    TCUtil.getResearchPrerequisites(list, researchItemRod);
-                }
-                if (rectangleCap.contains(mousePos.x, mousePos.y)) {
-                    TCUtil.getResearchPrerequisites(list, researchItemCap);
-                }
-            } else if (cRecipe instanceof ArcaneShapedCachedRecipe) {
-                ArcaneShapedCachedRecipe recipe = (ArcaneShapedCachedRecipe) cRecipe;
-                Rectangle rectangle = getResearchNormalRect(gui, recipeIndex);
-                if (rectangle.contains(mousePos.x, mousePos.y)) {
-                    TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+        if (TCNAConfig.showResearchKey) {
+            if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
+                CachedRecipe cRecipe = arecipes.get(recipeIndex);
+                ItemStack result = cRecipe.getResult().item;
+                Point mousePos = GuiDraw.getMousePosition();
+                if (result.getItem() instanceof ItemWandCasting) {
+                    ItemWandCasting wand = (ItemWandCasting) result.getItem();
+                    WandRod rod = wand.getRod(result);
+                    WandCap cap = wand.getCap(result);
+                    ResearchItem researchItemRod = ResearchCategories.getResearch(rod.getResearch());
+                    ResearchItem researchItemCap = ResearchCategories.getResearch(cap.getResearch());
+                    Rectangle rectangleRod = getResearchRodRect(gui, recipeIndex);
+                    Rectangle rectangleCap = getResearchCapRect(gui, recipeIndex);
+                    if (rectangleRod.contains(mousePos.x, mousePos.y)) {
+                        TCUtil.getResearchPrerequisites(list, researchItemRod);
+                    }
+                    if (rectangleCap.contains(mousePos.x, mousePos.y)) {
+                        TCUtil.getResearchPrerequisites(list, researchItemCap);
+                    }
+                } else if (cRecipe instanceof ArcaneShapedCachedRecipe) {
+                    ArcaneShapedCachedRecipe recipe = (ArcaneShapedCachedRecipe) cRecipe;
+                    Rectangle rectangle = getResearchNormalRect(gui, recipeIndex);
+                    if (rectangle.contains(mousePos.x, mousePos.y)) {
+                        TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+                    }
                 }
             }
         }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
@@ -159,7 +159,7 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
                 ArcaneShapelessCachedRecipe recipe = (ArcaneShapelessCachedRecipe) arecipes.get(recipeIndex);
                 Rectangle rectangle = getResearchRect(gui, recipeIndex);
                 Point mousePos = GuiDraw.getMousePosition();
-                if (rectangle.contains(mousePos.x, mousePos.y)) {
+                if (rectangle.contains(mousePos)) {
                     TCUtil.getResearchPrerequisites(list, recipe.researchItem);
                 }
             }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
@@ -154,12 +154,14 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
 
     @Override
     public List<String> handleTooltip(GuiRecipe gui, List<String> list, int recipeIndex) {
-        if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
-            ArcaneShapelessCachedRecipe recipe = (ArcaneShapelessCachedRecipe) arecipes.get(recipeIndex);
-            Rectangle rectangle = getResearchRect(gui, recipeIndex);
-            Point mousePos = GuiDraw.getMousePosition();
-            if (rectangle.contains(mousePos.x, mousePos.y)) {
-                TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+        if (TCNAConfig.showResearchKey) {
+            if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
+                ArcaneShapelessCachedRecipe recipe = (ArcaneShapelessCachedRecipe) arecipes.get(recipeIndex);
+                Rectangle rectangle = getResearchRect(gui, recipeIndex);
+                Point mousePos = GuiDraw.getMousePosition();
+                if (rectangle.contains(mousePos.x, mousePos.y)) {
+                    TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+                }
             }
         }
         return super.handleTooltip(gui, list, recipeIndex);

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
@@ -3,6 +3,8 @@ package ru.timeconqueror.tcneiadditions.nei.arcaneworkbench;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
+import codechicken.nei.guihook.GuiContainerManager;
+import codechicken.nei.recipe.GuiRecipe;
 import com.djgiannuzz.thaumcraftneiplugin.items.ItemAspect;
 import com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper;
 import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.ArcaneShapelessRecipeHandler;
@@ -15,17 +17,22 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
+import ru.timeconqueror.tcneiadditions.util.GuiRecipeHelper;
 import ru.timeconqueror.tcneiadditions.util.TCNAConfig;
 import ru.timeconqueror.tcneiadditions.util.TCUtil;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.ShapelessArcaneRecipe;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
 import thaumcraft.client.lib.UtilsFX;
 
 public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler {
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
+    private int ySize;
 
     @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
@@ -123,8 +130,18 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
 
         if (TCNAConfig.showResearchKey) {
             int y = 135;
-            String textToDraw = I18n.format("tcneiadditions.research.researchKey", recipe.researchKey);
-            for (Object text : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(textToDraw, 162)) {
+            String researchString = recipe.researchItem != null
+                    ? EnumChatFormatting.UNDERLINE
+                            + ResearchCategories.getCategoryName(recipe.researchItem.category) + " : "
+                            + recipe.researchItem.getName()
+                    : EnumChatFormatting.ITALIC + "null";
+            List listResearchString =
+                    Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(researchString, 162);
+            this.ySize = listResearchString.size() * 11;
+            List<Object> list = new ArrayList<>();
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.researchName") + ":");
+            list.addAll(listResearchString);
+            for (Object text : list) {
                 GuiDraw.drawStringC((String) text, 82, y, Color.BLACK.getRGB(), false);
                 y += 11;
             }
@@ -135,11 +152,33 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
         return NEIServerUtils.extractRecipeItems(input).length != 0;
     }
 
+    @Override
+    public List<String> handleTooltip(GuiRecipe gui, List<String> list, int recipeIndex) {
+        if (GuiContainerManager.shouldShowTooltip(gui) && list.size() == 0) {
+            ArcaneShapelessCachedRecipe recipe = (ArcaneShapelessCachedRecipe) arecipes.get(recipeIndex);
+            Rectangle rectangle = getResearchRect(gui, recipeIndex);
+            Point mousePos = GuiDraw.getMousePosition();
+            if (rectangle.contains(mousePos.x, mousePos.y)) {
+                TCUtil.getResearchPrerequisites(list, recipe.researchItem);
+            }
+        }
+        return super.handleTooltip(gui, list, recipeIndex);
+    }
+
+    protected Rectangle getResearchRect(GuiRecipe gui, int recipeIndex) {
+        Point offset = gui.getRecipePosition(recipeIndex);
+        return new Rectangle(
+                GuiRecipeHelper.getGuiLeft(gui) + offset.x + 2,
+                GuiRecipeHelper.getGuiTop(gui) + offset.y + 146,
+                GuiRecipeHelper.getXSize(gui) - 9,
+                this.ySize);
+    }
+
     private class ArcaneShapelessCachedRecipe extends CachedShapelessRecipe implements IArcaneOverlayProvider {
         private final AspectList aspects;
         protected Object[] overlay;
         private final boolean shouldShowRecipe;
-        private final String researchKey;
+        private final ResearchItem researchItem;
 
         public ArcaneShapelessCachedRecipe(ShapelessArcaneRecipe recipe, boolean shouldShowRecipe) {
             super(recipe.getInput(), recipe.getRecipeOutput());
@@ -147,7 +186,7 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
             this.overlay = recipe.getInput().toArray();
             this.aspects = recipe.getAspects();
             this.shouldShowRecipe = shouldShowRecipe;
-            this.researchKey = recipe.getResearch() != null ? recipe.getResearch() : EnumChatFormatting.ITALIC + "null";
+            this.researchItem = ResearchCategories.getResearch(recipe.getResearch());
             NEIHelper.addAspectsToIngredients(this.aspects, this.ingredients, 0);
         }
 

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/GuiRecipeHelper.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/GuiRecipeHelper.java
@@ -1,0 +1,96 @@
+package ru.timeconqueror.tcneiadditions.util;
+
+import codechicken.nei.recipe.GuiRecipe;
+import cpw.mods.fml.common.FMLLog;
+import java.lang.reflect.Field;
+import net.minecraft.client.Minecraft;
+import org.apache.logging.log4j.Level;
+
+/**
+ * From GTNEIOrePlugin By YannickMG
+ */
+public class GuiRecipeHelper {
+    private static final String INIT_ERROR =
+            "ru.timeconqueror.tcneiadditions.util.GuiRecipeHelper failed setting up reflection : ";
+    private static final int DEFAULT_XSIZE = 176;
+
+    public static Field xSizeField;
+    public static Field guiLeftField;
+    public static Field guiTopField;
+
+    /**
+     * Access the xSize field of a GuiRecipe instance, or use a fallback hardcoded value if that fails
+     *
+     * @param gui GuiRecipe object
+     * @return Integer value of the xSize field of that object
+     */
+    public static int getXSize(GuiRecipe gui) {
+        if (xSizeField != null) {
+            try {
+                return (int) xSizeField.get(gui);
+            } catch (IllegalAccessException e) {
+                // Fail silently, hoping that it it fails it will be during initialization
+            }
+        }
+
+        // Fallback should work unless codechicken.nei.recipe.GuiRecipe implementation changes
+        return DEFAULT_XSIZE;
+    }
+
+    /**
+     * Access the guiLeft field of a GuiRecipe instance, or use a fallback hardcoded value if that fails
+     *
+     * @param gui GuiRecipe object
+     * @return Integer value of the guiLeft field of that object
+     */
+    public static int getGuiLeft(GuiRecipe gui) {
+        if (guiLeftField != null) {
+            try {
+                return (int) guiLeftField.get(gui);
+            } catch (IllegalAccessException e) {
+                // Fail silently, hoping that it it fails it will be during initialization
+            }
+        }
+
+        // Fallback should work unless codechicken.nei.recipe.GuiRecipe implementation changes
+        return (Minecraft.getMinecraft().currentScreen.width - DEFAULT_XSIZE) / 2;
+    }
+
+    /**
+     * Access the guiTop field of a GuiRecipe instance, or use a fallback hardcoded value if that fails
+     *
+     * @param gui GuiRecipe object
+     * @return Integer value of the guiTop field of that object
+     */
+    public static int getGuiTop(GuiRecipe gui) {
+        if (guiTopField != null) {
+            try {
+                return (int) guiTopField.get(gui);
+            } catch (IllegalAccessException e) {
+                // Fail silently, hoping that it it fails it will be during initialization
+            }
+        }
+
+        // Fallback should work unless codechicken.nei.recipe.GuiRecipe implementation changes
+        int height = Minecraft.getMinecraft().currentScreen.height;
+        int ySize = Math.min(Math.max(height - 68, 166), 370);
+        return (height - ySize) / 2 + 10;
+    }
+
+    /**
+     * Initialize the GuiRecipe Field accessors through reflection
+     */
+    public GuiRecipeHelper() {
+        Class<GuiRecipe> guiRecipeClass = GuiRecipe.class;
+        try {
+            guiLeftField = guiRecipeClass.getField("guiLeft");
+            guiLeftField.setAccessible(true);
+            guiTopField = guiRecipeClass.getField("guiTop");
+            guiTopField.setAccessible(true);
+            xSizeField = guiRecipeClass.getField("xSize");
+            xSizeField.setAccessible(true);
+        } catch (NoSuchFieldException | SecurityException e) {
+            FMLLog.log(Level.ERROR, INIT_ERROR + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
@@ -183,7 +183,7 @@ public class TCUtil {
                 }
             }
             if (researchItem.parentsHidden.length > 10 && needResearch == 0) {
-                list.add(EnumChatFormatting.GREEN
+                list.add(EnumChatFormatting.GREEN + "    "
                         + StatCollector.translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
             }
         }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
@@ -135,93 +135,48 @@ public class TCUtil {
         return Collections.singletonList(stack);
     }
 
-    public static List<String> getResearchPrerequisites(List<String> list, ResearchItem researchItem) {
-        if (researchItem == null) return list;
-        String playerName = Minecraft.getMinecraft().getSession().getUsername();
-        // Parent research
-        if (researchItem.parents != null && researchItem.parents.length != 0) {
-            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.parents") + ":");
-            int needResearch = 0;
-            for (String researchKey : researchItem.parents) {
-                String researchName =
-                        ResearchCategories.getCategoryName(ResearchCategories.getResearch(researchKey).category) + " : "
-                                + ResearchCategories.getResearch(researchKey).getName();
-                if (ResearchManager.isResearchComplete(playerName, researchKey)) {
-                    if (researchItem.parents.length <= 10) {
-                        researchName = EnumChatFormatting.GREEN + "" + EnumChatFormatting.STRIKETHROUGH + researchName;
-                        list.add(EnumChatFormatting.RESET + "    " + researchName);
+    public static void getResearchPrerequisites(List<String> list, ResearchItem researchItem) {
+        if (researchItem != null) {
+            String playerName = Minecraft.getMinecraft().getSession().getUsername();
+            // Parent research
+            getResearchListBuName(list, researchItem.parents, playerName, "parents");
+            // Parent hidden research
+            getResearchListBuName(list, researchItem.parentsHidden, playerName, "parentsHidden");
+            // Item scan
+            if (researchItem.getItemTriggers() != null && researchItem.getItemTriggers().length != 0) {
+                list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.item") + ":");
+                for (ItemStack itemStack : researchItem.getItemTriggers()) {
+                    String displayName = itemStack.getDisplayName();
+                    list.add("    " + displayName);
+                }
+            }
+            // Entity scan
+            if (researchItem.getEntityTriggers() != null && researchItem.getEntityTriggers().length != 0) {
+                list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.entity") + ":");
+                for (String entityKey : researchItem.getEntityTriggers()) {
+                    String entityName = StatCollector.translateToLocal("entity." + entityKey + ".name");
+                    list.add("    " + entityName);
+                }
+            }
+            // Aspect scan
+            if (researchItem.getAspectTriggers() != null && researchItem.getAspectTriggers().length != 0) {
+                list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.aspect") + ":");
+                for (Aspect aspect : researchItem.getAspectTriggers()) {
+                    String aspectName = aspect.getName() + " - " + aspect.getLocalizedDescription();
+                    list.add("    " + aspectName);
+                }
+            }
+            // Kill scan
+            if (Loader.isModLoaded("Automagy") && researchItem.category.equals("AUTOMAGY")) {
+                Set<String> killList = getKeysByValue(ModResearchItems.cluesOnKill, researchItem.key);
+                if (!killList.isEmpty()) {
+                    list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.kill") + ":");
+                    for (String entityKey : killList) {
+                        list.add("    " + StatCollector.translateToLocal("entity." + entityKey + ".name"));
                     }
-                } else {
-                    needResearch++;
-                    researchName = EnumChatFormatting.RED + researchName;
-                    list.add(EnumChatFormatting.RESET + "    " + researchName);
-                }
-            }
-            if (researchItem.parents.length > 10 && needResearch == 0) {
-                list.add(EnumChatFormatting.GREEN
-                        + StatCollector.translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
-            }
-        }
-        // Parent hidden research
-        if (researchItem.parentsHidden != null && researchItem.parentsHidden.length != 0) {
-            int needResearch = 0;
-            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.parentsHidden") + ":");
-            for (String researchKey : researchItem.parentsHidden) {
-                String researchName =
-                        ResearchCategories.getCategoryName(ResearchCategories.getResearch(researchKey).category)
-                                + " : "
-                                + ResearchCategories.getResearch(researchKey).getName();
-                if (ResearchManager.isResearchComplete(playerName, researchKey)) {
-                    if (researchItem.parentsHidden.length <= 10) {
-                        researchName = EnumChatFormatting.GREEN + "" + EnumChatFormatting.STRIKETHROUGH + researchName;
-                        list.add(EnumChatFormatting.RESET + "    " + researchName);
-                    }
-                } else {
-                    needResearch++;
-                    researchName = EnumChatFormatting.RED + researchName;
-                    list.add(EnumChatFormatting.RESET + "    " + researchName);
-                }
-            }
-            if (researchItem.parentsHidden.length > 10 && needResearch == 0) {
-                list.add(EnumChatFormatting.GREEN + "    "
-                        + StatCollector.translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
-            }
-        }
-        // Item scan
-        if (researchItem.getItemTriggers() != null && researchItem.getItemTriggers().length != 0) {
-            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.item") + ":");
-            for (ItemStack itemStack : researchItem.getItemTriggers()) {
-                String displayName = itemStack.getDisplayName();
-                list.add("    " + displayName);
-            }
-        }
-        // Entity scan
-        if (researchItem.getEntityTriggers() != null && researchItem.getEntityTriggers().length != 0) {
-            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.entity") + ":");
-            for (String entityKey : researchItem.getEntityTriggers()) {
-                String entityName = StatCollector.translateToLocal("entity." + entityKey + ".name");
-                list.add("    " + entityName);
-            }
-        }
-        // Aspect scan
-        if (researchItem.getAspectTriggers() != null && researchItem.getAspectTriggers().length != 0) {
-            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.aspect") + ":");
-            for (Aspect aspect : researchItem.getAspectTriggers()) {
-                String aspectName = aspect.getName() + " - " + aspect.getLocalizedDescription();
-                list.add("    " + aspectName);
-            }
-        }
-        // Kill scan
-        if (Loader.isModLoaded("Automagy") && researchItem.category.equals("AUTOMAGY")) {
-            Set<String> killList = getKeysByValue(ModResearchItems.cluesOnKill, researchItem.key);
-            if (!killList.isEmpty()) {
-                list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.kill") + ":");
-                for (String entityKey : killList) {
-                    list.add("    " + StatCollector.translateToLocal("entity." + entityKey + ".name"));
                 }
             }
         }
-        return list;
     }
 
     public static <T, E> Set<T> getKeysByValue(Map<T, E> map, E value) {
@@ -229,5 +184,32 @@ public class TCUtil {
                 .filter(entry -> Objects.equals(entry.getValue(), value))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
+    }
+
+    public static void getResearchListBuName(List<String> list, String[] researchKeys, String playerName, String keysName) {
+        if (researchKeys != null && researchKeys.length != 0) {
+            int needResearch = 0;
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites." + keysName )+ ":");
+            for (String researchKey : researchKeys) {
+                String researchName =
+                        ResearchCategories.getCategoryName(ResearchCategories.getResearch(researchKey).category)
+                                + " : "
+                                + ResearchCategories.getResearch(researchKey).getName();
+                if (ResearchManager.isResearchComplete(playerName, researchKey)) {
+                    if (researchKeys.length <= 10) {
+                        researchName = EnumChatFormatting.GREEN + "" + EnumChatFormatting.STRIKETHROUGH + researchName;
+                        list.add(EnumChatFormatting.RESET + "    " + researchName);
+                    }
+                } else {
+                    needResearch++;
+                    researchName = EnumChatFormatting.RED + researchName;
+                    list.add(EnumChatFormatting.RESET + "    " + researchName);
+                }
+            }
+            if (researchKeys.length > 10 && needResearch == 0) {
+                list.add(EnumChatFormatting.GREEN + "    "
+                        + StatCollector.translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
+            }
+        }
     }
 }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
@@ -3,16 +3,23 @@ package ru.timeconqueror.tcneiadditions.util;
 import codechicken.nei.NEIServerUtils;
 import com.djgiannuzz.thaumcraftneiplugin.items.ItemAspect;
 import com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import cpw.mods.fml.common.Loader;
+import java.util.*;
+import java.util.stream.Collectors;
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.oredict.OreDictionary;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.ThaumcraftApiHelper;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.crafting.CrucibleRecipe;
 import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.common.lib.research.ResearchManager;
+import tuhljin.automagy.config.ModResearchItems;
 
 public class TCUtil {
     public static List<InfusionRecipe> getInfusionRecipes(ItemStack result) {
@@ -126,5 +133,104 @@ public class TCUtil {
             }
         }
         return Collections.singletonList(stack);
+    }
+
+    public static List<String> getResearchPrerequisites(List<String> list, ResearchItem researchItem) {
+        if (researchItem == null) return list;
+        String playerName = Minecraft.getMinecraft().getSession().getUsername();
+        // Parent research
+        if (researchItem.parents != null && researchItem.parents.length != 0) {
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.parents") + ":");
+            int needResearch = 0;
+            for (String researchKey : researchItem.parents) {
+                String researchName =
+                        ResearchCategories.getCategoryName(ResearchCategories.getResearch(researchKey).category) + " : "
+                                + ResearchCategories.getResearch(researchKey).getName();
+                if (ResearchManager.isResearchComplete(playerName, researchKey)) {
+                    if (researchItem.parents.length <= 10) {
+                        researchName = EnumChatFormatting.GREEN + "" + EnumChatFormatting.STRIKETHROUGH + researchName;
+                        list.add(EnumChatFormatting.RESET + "    " + researchName);
+                    }
+                } else {
+                    needResearch++;
+                    researchName = EnumChatFormatting.RED + researchName;
+                    list.add(EnumChatFormatting.RESET + "    " + researchName);
+                }
+            }
+            if (researchItem.parents.length > 10 && needResearch == 0) {
+                list.add(EnumChatFormatting.GREEN
+                        + StatCollector.translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
+            }
+        }
+        // Parent hidden research
+        if (researchItem.parentsHidden != null) {
+            if (researchItem.parents != null && researchItem.parents.length != 0) {
+                int needResearch = 0;
+                list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.parentsHidden") + ":");
+                for (String researchKey : researchItem.parentsHidden) {
+                    String researchName = ResearchCategories.getCategoryName(
+                                    ResearchCategories.getResearch(researchKey).category)
+                            + " : "
+                            + ResearchCategories.getResearch(researchKey).getName();
+                    if (ResearchManager.isResearchComplete(playerName, researchKey)) {
+                        if (researchItem.parents.length <= 10) {
+                            researchName =
+                                    EnumChatFormatting.GREEN + "" + EnumChatFormatting.STRIKETHROUGH + researchName;
+                            list.add(EnumChatFormatting.RESET + "    " + researchName);
+                        }
+                    } else {
+                        needResearch++;
+                        researchName = EnumChatFormatting.RED + researchName;
+                        list.add(EnumChatFormatting.RESET + "    " + researchName);
+                    }
+                }
+                if (researchItem.parentsHidden.length > 10 && needResearch == 0) {
+                    list.add(EnumChatFormatting.GREEN
+                            + StatCollector.translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
+                }
+            }
+        }
+        // Item scan
+        if (researchItem.getItemTriggers() != null && researchItem.getItemTriggers().length != 0) {
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.item") + ":");
+            for (ItemStack itemStack : researchItem.getItemTriggers()) {
+                String displayName = itemStack.getDisplayName();
+                list.add("    " + displayName);
+            }
+        }
+        // Entity scan
+        if (researchItem.getEntityTriggers() != null && researchItem.getEntityTriggers().length != 0) {
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.entity") + ":");
+            for (String entityKey : researchItem.getEntityTriggers()) {
+                String entityName = StatCollector.translateToLocal("entity." + entityKey + ".name");
+                list.add("    " + entityName);
+            }
+        }
+        // Aspect scan
+        if (researchItem.getAspectTriggers() != null && researchItem.getAspectTriggers().length != 0) {
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.aspect") + ":");
+            for (Aspect aspect : researchItem.getAspectTriggers()) {
+                String aspectName = aspect.getName() + " - " + aspect.getLocalizedDescription();
+                list.add("    " + aspectName);
+            }
+        }
+        // Kill scan
+        if (Loader.isModLoaded("Automagy") && researchItem.category.equals("AUTOMAGY")) {
+            Set<String> killList = getKeysByValue(ModResearchItems.cluesOnKill, researchItem.key);
+            if (!killList.isEmpty()) {
+                list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.kill") + ":");
+                for (String entityKey : killList) {
+                    list.add("    " + StatCollector.translateToLocal("entity." + entityKey + ".name"));
+                }
+            }
+        }
+        return list;
+    }
+
+    public static <T, E> Set<T> getKeysByValue(Map<T, E> map, E value) {
+        return map.entrySet().stream()
+                .filter(entry -> Objects.equals(entry.getValue(), value))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
@@ -163,31 +163,28 @@ public class TCUtil {
             }
         }
         // Parent hidden research
-        if (researchItem.parentsHidden != null) {
-            if (researchItem.parents != null && researchItem.parents.length != 0) {
-                int needResearch = 0;
-                list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.parentsHidden") + ":");
-                for (String researchKey : researchItem.parentsHidden) {
-                    String researchName = ResearchCategories.getCategoryName(
-                                    ResearchCategories.getResearch(researchKey).category)
-                            + " : "
-                            + ResearchCategories.getResearch(researchKey).getName();
-                    if (ResearchManager.isResearchComplete(playerName, researchKey)) {
-                        if (researchItem.parents.length <= 10) {
-                            researchName =
-                                    EnumChatFormatting.GREEN + "" + EnumChatFormatting.STRIKETHROUGH + researchName;
-                            list.add(EnumChatFormatting.RESET + "    " + researchName);
-                        }
-                    } else {
-                        needResearch++;
-                        researchName = EnumChatFormatting.RED + researchName;
+        if (researchItem.parentsHidden != null && researchItem.parentsHidden.length != 0) {
+            int needResearch = 0;
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.parentsHidden") + ":");
+            for (String researchKey : researchItem.parentsHidden) {
+                String researchName =
+                        ResearchCategories.getCategoryName(ResearchCategories.getResearch(researchKey).category)
+                                + " : "
+                                + ResearchCategories.getResearch(researchKey).getName();
+                if (ResearchManager.isResearchComplete(playerName, researchKey)) {
+                    if (researchItem.parentsHidden.length <= 10) {
+                        researchName = EnumChatFormatting.GREEN + "" + EnumChatFormatting.STRIKETHROUGH + researchName;
                         list.add(EnumChatFormatting.RESET + "    " + researchName);
                     }
+                } else {
+                    needResearch++;
+                    researchName = EnumChatFormatting.RED + researchName;
+                    list.add(EnumChatFormatting.RESET + "    " + researchName);
                 }
-                if (researchItem.parentsHidden.length > 10 && needResearch == 0) {
-                    list.add(EnumChatFormatting.GREEN
-                            + StatCollector.translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
-                }
+            }
+            if (researchItem.parentsHidden.length > 10 && needResearch == 0) {
+                list.add(EnumChatFormatting.GREEN
+                        + StatCollector.translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
             }
         }
         // Item scan

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
@@ -139,9 +139,9 @@ public class TCUtil {
         if (researchItem != null) {
             String playerName = Minecraft.getMinecraft().getSession().getUsername();
             // Parent research
-            getResearchListBuName(list, researchItem.parents, playerName, "parents");
+            getResearchListByName(list, researchItem.parents, playerName, "parents");
             // Parent hidden research
-            getResearchListBuName(list, researchItem.parentsHidden, playerName, "parentsHidden");
+            getResearchListByName(list, researchItem.parentsHidden, playerName, "parentsHidden");
             // Item scan
             if (researchItem.getItemTriggers() != null && researchItem.getItemTriggers().length != 0) {
                 list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites.item") + ":");
@@ -186,7 +186,7 @@ public class TCUtil {
                 .collect(Collectors.toSet());
     }
 
-    public static void getResearchListBuName(
+    public static void getResearchListByName(
             List<String> list, String[] researchKeys, String playerName, String keysName) {
         if (researchKeys != null && researchKeys.length != 0) {
             int needResearch = 0;

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
@@ -186,10 +186,11 @@ public class TCUtil {
                 .collect(Collectors.toSet());
     }
 
-    public static void getResearchListBuName(List<String> list, String[] researchKeys, String playerName, String keysName) {
+    public static void getResearchListBuName(
+            List<String> list, String[] researchKeys, String playerName, String keysName) {
         if (researchKeys != null && researchKeys.length != 0) {
             int needResearch = 0;
-            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites." + keysName )+ ":");
+            list.add(StatCollector.translateToLocal("tcneiadditions.research.prerequisites." + keysName) + ":");
             for (String researchKey : researchKeys) {
                 String researchName =
                         ResearchCategories.getCategoryName(ResearchCategories.getResearch(researchKey).category)

--- a/src/main/resources/assets/tcneiadditions/lang/en_US.lang
+++ b/src/main/resources/assets/tcneiadditions/lang/en_US.lang
@@ -3,9 +3,17 @@ tcneiadditions.aspect_from_itemstack.still_load=Still loading... (%s/%s)
 tcneiadditions.aspect_combination.title=Aspect Combination
 
 tcneiadditions.research.missing=You haven't completed research required to craft this item
-tcneiadditions.research.researchKey=Research key: %s
-tcneiadditions.research.researchKey_rod=Rod Research key: %s
-tcneiadditions.research.researchKey_cap=Cap Research key: %s
+tcneiadditions.research.researchName=Research name
+tcneiadditions.research.researchName_rod=Rod Research name
+tcneiadditions.research.researchName_cap=Cap Research name
+tcneiadditions.research.prerequisites.parents=Parent research
+tcneiadditions.research.prerequisites.parentsHidden=Parent hidden research
+tcneiadditions.research.prerequisites.item=Scan item
+tcneiadditions.research.prerequisites.entity=Scan entity
+tcneiadditions.research.prerequisites.aspect=Scan aspect
+tcneiadditions.research.prerequisites.kill=Kill and Scan
+tcneiadditions.research.prerequisites.allresearched=You have done all the required research
+
 
 tcneiadditions.config.general=General
 


### PR DESCRIPTION
it will display the research name and the name of research category instead of research key.
![@VGARLQ`~(J()$55I }%N}V](https://user-images.githubusercontent.com/62897714/197588940-e9b6a1ff-2ea9-42b0-9faf-c31b6c83e475.png)

that's research prerequisites, research that is not unlocked will be displayed in red.
![FMGU3@J` ~@GVAA `0QBRQV](https://user-images.githubusercontent.com/62897714/197589416-22511c5e-7e74-48ff-b5c2-8321dc59ac90.png)
![PND2Y3(BE{0`8T5FEJ@Q%5W](https://user-images.githubusercontent.com/62897714/197589439-1080dc8f-a933-4e81-8d89-a7f16787528c.png)
![JKD7)3SQN E)0DN@%RFAKT6](https://user-images.githubusercontent.com/62897714/197589462-e6d5119f-7b07-472d-a6ef-a3d7595f5202.png)

unlocked research will be displayed in green.
![CB%RUF2682DO%}5WC`Q5O86](https://user-images.githubusercontent.com/62897714/197589758-fefda201-8c54-4f85-b2e0-a6baa56974a9.png)

the unlocked research will disappear if needed research > 10, and it will display this in the end.
![_O@EAFX QI%}R@~UKTY5791](https://user-images.githubusercontent.com/62897714/197590347-6f37f806-1701-429f-a420-6464359a43f9.png)

(That's Ichor, if all the research is locked)
![Y%32) @GK9FA%ER@5TE`%ZS](https://user-images.githubusercontent.com/62897714/197590472-8bfe6494-9aad-4eab-8b9c-d804b25f311a.png)

special thanks GuiRecipeHelper by YannickMG