### PR TITLE
TC Aspects not showing up on bookmarks correctly fix.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1682616243
+//version: 1683563728
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -71,6 +71,9 @@ plugins {
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
     id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
 }
+
+print("You might want to check out './gradlew :faq' if your build fails.\n")
+
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
 if (settingsupdated)
@@ -219,6 +222,8 @@ if (enableModernJavaSyntax.toBoolean()) {
 
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
+        // workaround for https://github.com/bsideup/jabel/issues/174
+        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
@@ -1249,6 +1254,21 @@ if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISA
         if (gradle.gradleVersion != buildscriptGradleVersion) {
             out.style(Style.SuccessHeader).println("updateBuildScript can update gradle from ${gradle.gradleVersion} to ${buildscriptGradleVersion}\n")
         }
+    }
+}
+
+// If you want to add more cases to this task, implement them as arguments if total amount to print gets too large
+tasks.register('faq') {
+    group = 'GTNH Buildscript'
+    description = 'Prints frequently asked questions about building a project'
+
+    doLast {
+        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
+            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
+            "The links can be found in repositories.gradle and build.gradle:repositories, " +
+            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+            "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
     }
 }
 

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
@@ -4,6 +4,7 @@ import java.awt.*;
 import java.util.*;
 import java.util.List;
 
+import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -25,6 +26,7 @@ import ru.timeconqueror.tcneiadditions.util.GuiRecipeHelper;
 import ru.timeconqueror.tcneiadditions.util.TCNAConfig;
 import ru.timeconqueror.tcneiadditions.util.TCUtil;
 import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.CrucibleRecipe;
 import thaumcraft.api.research.ResearchCategories;
@@ -104,6 +106,31 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
     }
 
     @Override
+    public void drawAspects(int recipe, int x, int y)
+    {
+        AspectList aspects = this.aspectsAmount.get(recipe);
+        int aspectsPerRow = 3;
+        int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
+
+        int xBase = x + 8;
+        int yBase = y + 75 + 32 - 10 * rows;
+        int count = 0;
+
+        for (int row = 0; row < rows; row++)
+        {
+            int columns = Math.min(aspects.size() - row * 3, 3);
+            int offSet = (100 - columns * 20) / 2;
+            for (int column = 0; column < columns; column++)
+            {
+                Aspect aspect = aspects.getAspectsSortedAmount()[count++];
+                int posX = xBase + column * 20 + offSet;
+                int posY = yBase + row * 20;
+                UtilsFX.drawTag(posX, posY, aspect, 0, 0, GuiDraw.gui.getZLevel());
+            }
+        }
+    }
+
+    @Override
     public void drawExtras(int recipeIndex) {
         CrucibleCachedRecipe recipe = (CrucibleCachedRecipe) arecipes.get(recipeIndex);
         if (recipe.shouldShowRecipe) {
@@ -175,7 +202,7 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
             this.setAspectList(recipe.aspects);
             this.shouldShowRecipe = shouldShowRecipe;
             this.researchItem = ResearchCategories.getResearch(recipe.key);
-            NEIHelper.addAspectsToIngredients(this.aspects, this.ingredients, 2);
+            this.addAspectsToIngredients(aspects);
         }
 
         protected void setIngredient(Object in) {
@@ -233,6 +260,30 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
                 return false;
             }
             return super.contains(ingredients, ingredient);
+        }
+
+        protected void addAspectsToIngredients(AspectList aspects) {
+            int aspectsPerRow = 3;
+            int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
+
+            int xBase =  23 + 8;
+            int yBase =  -21 + 75 + 32 - 10 * rows;
+            int count = 0;
+
+            for (int row = 0; row < rows; row++)
+            {
+                int columns = Math.min(aspects.size() - row * 3, 3);
+                int offSet = (100 - columns * 20) / 2;
+                for (int column = 0; column < columns; column++)
+                {
+                    Aspect aspect = aspects.getAspectsSortedAmount()[count++];
+                    int posX = xBase + column * 20 + offSet;
+                    int posY = yBase + row * 20;
+                    ItemStack stack = new ItemStack(ModItems.itemAspect, aspects.getAmount(aspect), 1);
+                    ItemAspect.setAspect(stack, aspect);
+                    this.ingredients.add(new PositionedStack(stack, posX, posY, false));
+                }
+            }
         }
     }
 }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
@@ -4,7 +4,6 @@ import java.awt.*;
 import java.util.*;
 import java.util.List;
 
-import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -13,8 +12,8 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
+import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import com.djgiannuzz.thaumcraftneiplugin.items.ItemAspect;
-import com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper;
 import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.CrucibleRecipeHandler;
 
 import codechicken.lib.gui.GuiDraw;
@@ -106,8 +105,7 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
     }
 
     @Override
-    public void drawAspects(int recipe, int x, int y)
-    {
+    public void drawAspects(int recipe, int x, int y) {
         AspectList aspects = this.aspectsAmount.get(recipe);
         int aspectsPerRow = 3;
         int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
@@ -116,12 +114,10 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
         int yBase = y + 75 + 32 - 10 * rows;
         int count = 0;
 
-        for (int row = 0; row < rows; row++)
-        {
+        for (int row = 0; row < rows; row++) {
             int columns = Math.min(aspects.size() - row * 3, 3);
             int offSet = (100 - columns * 20) / 2;
-            for (int column = 0; column < columns; column++)
-            {
+            for (int column = 0; column < columns; column++) {
                 Aspect aspect = aspects.getAspectsSortedAmount()[count++];
                 int posX = xBase + column * 20 + offSet;
                 int posY = yBase + row * 20;
@@ -266,16 +262,14 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
             int aspectsPerRow = 3;
             int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
 
-            int xBase =  23 + 8;
-            int yBase =  -21 + 75 + 32 - 10 * rows;
+            int xBase = 23 + 8;
+            int yBase = -21 + 75 + 32 - 10 * rows;
             int count = 0;
 
-            for (int row = 0; row < rows; row++)
-            {
+            for (int row = 0; row < rows; row++) {
                 int columns = Math.min(aspects.size() - row * 3, 3);
                 int offSet = (100 - columns * 20) / 2;
-                for (int column = 0; column < columns; column++)
-                {
+                for (int column = 0; column < columns; column++) {
                     Aspect aspect = aspects.getAspectsSortedAmount()[count++];
                     int posX = xBase + column * 20 + offSet;
                     int posY = yBase + row * 20;

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
@@ -105,6 +105,7 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
         GL11.glPopMatrix();
     }
 
+    // Math in these looks a little weird to show similarity to other method above.
     @Override
     public void drawAspects(int recipe, int x, int y) {
         AspectList aspects = this.aspectsAmount.get(recipe);
@@ -258,6 +259,7 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
             return super.contains(ingredients, ingredient);
         }
 
+        // Math in these looks a little weird to show similarity to other method above.
         protected void addAspectsToIngredients(AspectList aspects) {
             int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
 

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
@@ -36,6 +36,7 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
 
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
     private int ySize;
+    private final int aspectsPerRow = 3;
 
     @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
@@ -107,11 +108,10 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
     @Override
     public void drawAspects(int recipe, int x, int y) {
         AspectList aspects = this.aspectsAmount.get(recipe);
-        int aspectsPerRow = 3;
         int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
 
         int xBase = x + 8;
-        int yBase = y + 75 + 32 - 10 * rows;
+        int yBase = y + 107 - (10 * rows);
         int count = 0;
 
         for (int row = 0; row < rows; row++) {
@@ -259,11 +259,10 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
         }
 
         protected void addAspectsToIngredients(AspectList aspects) {
-            int aspectsPerRow = 3;
             int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
 
             int xBase = 23 + 8;
-            int yBase = -21 + 75 + 32 - 10 * rows;
+            int yBase = -21 + 107 - (10 * rows);
             int count = 0;
 
             for (int row = 0; row < rows; row++) {

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -162,7 +162,7 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
                 Aspect aspect = aspects.getAspectsSortedAmount()[count++];
                 int posX = baseX + column * 20 + xOffset;
                 int posY = baseY + row * 20;
-                UtilsFX.drawTag(posX, posY, aspect, (float) aspects.getAmount(aspect), 0, GuiDraw.gui.getZLevel());
+                UtilsFX.drawTag(posX, posY, aspect, 0, 0, GuiDraw.gui.getZLevel());
             }
         }
     }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -343,7 +343,7 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
                     Aspect aspect = aspects.getAspectsSortedAmount()[count++];
                     int posX = baseX + column * 20 + xOffset;
                     int posY = baseY + row * 20;
-                    ItemStack stack = new ItemStack(ModItems.itemAspect, 1, 1);
+                    ItemStack stack = new ItemStack(ModItems.itemAspect, aspects.getAmount(aspect), 1);
                     ItemAspect.setAspect(stack, aspect);
                     this.ingredients.add(new PositionedStack(stack, posX, posY, false));
                 }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -39,6 +39,7 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
 
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
     private int ySize;
+    private final int aspectsPerRow = 7;
 
     @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
@@ -148,7 +149,6 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
     @Override
     public void drawAspects(int recipe, int x, int y) {
         AspectList aspects = this.aspectsAmount.get(recipe);
-        int aspectsPerRow = 7;
         int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
         int baseX = x + 8;
         int baseY = y + 173;
@@ -329,7 +329,6 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
         }
 
         protected void addAspectsToIngredients(AspectList aspects) {
-            int aspectsPerRow = 7;
             int rows = (int) Math.ceil((double) aspects.size() / aspectsPerRow);
             int baseX = 35;
             int baseY = 129;

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
@@ -1,12 +1,13 @@
 package ru.timeconqueror.tcneiadditions.nei.arcaneworkbench;
 
+import static com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper.getPrimalAspectListFromAmounts;
+
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -15,6 +16,7 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
+import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import com.djgiannuzz.thaumcraftneiplugin.items.ItemAspect;
 import com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper;
 import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.ArcaneShapedRecipeHandler;
@@ -39,8 +41,6 @@ import thaumcraft.api.wands.WandCap;
 import thaumcraft.api.wands.WandRod;
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.common.items.wands.ItemWandCasting;
-
-import static com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper.getPrimalAspectListFromAmounts;
 
 public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
 

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -38,6 +39,8 @@ import thaumcraft.api.wands.WandCap;
 import thaumcraft.api.wands.WandRod;
 import thaumcraft.client.lib.UtilsFX;
 import thaumcraft.common.items.wands.ItemWandCasting;
+
+import static com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper.getPrimalAspectListFromAmounts;
 
 public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
 
@@ -179,6 +182,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
 
         if (shouldShowRecipe) {
             super.drawBackground(recipeIndex);
+            this.drawAspects(recipeIndex);
             return;
         }
 
@@ -192,6 +196,23 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
         GL11.glScalef(1.7F, 1.7F, 1.0F);
         GuiDraw.drawTexturedModalRect(20, 7, 20, 3, 16, 16);
         GL11.glPopMatrix();
+    }
+
+    public void drawAspects(int recipe) {
+        int[] amounts = this.aspectsAmount.get(recipe);
+        AspectList aspects = getPrimalAspectListFromAmounts(amounts);
+
+        int baseX = 36;
+        int baseY = 115;
+        int count = 0;
+        int columns = aspects.size();
+        int xOffset = (100 - columns * 20) / 2;
+
+        for (int column = 0; column < columns; column++) {
+            Aspect aspect = aspects.getAspectsSortedAmount()[count++];
+            int posX = baseX + column * 18 + xOffset;
+            UtilsFX.drawTag(posX, baseY, aspect, 0, 0, GuiDraw.gui.getZLevel());
+        }
     }
 
     @Override
@@ -230,9 +251,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
             throw new RuntimeException("Incompatible recipe type found: " + cRecipe.getClass());
         }
 
-        if (shouldShowRecipe) {
-            super.drawExtras(recipeIndex);
-        } else {
+        if (!shouldShowRecipe) {
             String textToDraw = I18n.format("tcneiadditions.research.missing");
             int y = 28;
             for (Object text : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(textToDraw, 162)) {
@@ -314,7 +333,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
             this.height = recipe.height;
             this.shouldShowRecipe = shouldShowRecipe;
             this.researchItem = ResearchCategories.getResearch(recipe.getResearch());
-            NEIHelper.addAspectsToIngredients(this.aspects, this.ingredients, 0);
+            this.addAspectsToIngredients(aspects);
         }
 
         public boolean isValid() {
@@ -395,6 +414,24 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
 
             return stacks;
         }
+
+        protected void addAspectsToIngredients(AspectList aspects) {
+
+            int baseX = 36;
+            int baseY = 115;
+            int count = 0;
+            int columns = aspects.size();
+            int xOffset = (100 - columns * 20) / 2;
+
+            for (int column = 0; column < columns; column++) {
+                Aspect aspect = aspects.getAspectsSortedAmount()[count++];
+                int posX = baseX + column * 18 + xOffset;
+                ItemStack stack = new ItemStack(ModItems.itemAspect, aspects.getAmount(aspect), 1);
+                ItemAspect.setAspect(stack, aspect);
+                this.ingredients.add(new PositionedStack(stack, posX, baseY, false));
+            }
+        }
+
     }
 
     @Override
@@ -471,7 +508,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
             this.result = new PositionedStack(result, 74, 2);
             this.aspects = NEIHelper.getPrimalAspectListFromAmounts(NEIHelper.getWandAspectsWandCost(result));
             this.shouldShowRecipe = shouldShowRecipe;
-            NEIHelper.addAspectsToIngredients(this.aspects, this.ingredients, 0);
+            this.addAspectsToIngredients(aspects);
         }
 
         @Override
@@ -540,8 +577,24 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
                     }
                 }
             }
-
             return stacks;
+        }
+
+        protected void addAspectsToIngredients(AspectList aspects) {
+
+            int baseX = 36;
+            int baseY = 115;
+            int count = 0;
+            int columns = aspects.size();
+            int xOffset = (100 - columns * 20) / 2;
+
+            for (int column = 0; column < columns; column++) {
+                Aspect aspect = aspects.getAspectsSortedAmount()[count++];
+                int posX = baseX + column * 18 + xOffset;
+                ItemStack stack = new ItemStack(ModItems.itemAspect, aspects.getAmount(aspect), 1);
+                ItemAspect.setAspect(stack, aspect);
+                this.ingredients.add(new PositionedStack(stack, posX, baseY, false));
+            }
         }
     }
 }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
@@ -415,6 +415,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
             return stacks;
         }
 
+        // shaped crafting
         protected void addAspectsToIngredients(AspectList aspects) {
 
             int baseX = 36;
@@ -431,7 +432,6 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
                 this.ingredients.add(new PositionedStack(stack, posX, baseY, false));
             }
         }
-
     }
 
     @Override
@@ -580,6 +580,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
             return stacks;
         }
 
+        // Wand aspects
         protected void addAspectsToIngredients(AspectList aspects) {
 
             int baseX = 36;

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
@@ -1,12 +1,13 @@
 package ru.timeconqueror.tcneiadditions.nei.arcaneworkbench;
 
+import static com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper.getPrimalAspectListFromAmounts;
+
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -15,8 +16,8 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
+import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import com.djgiannuzz.thaumcraftneiplugin.items.ItemAspect;
-import com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper;
 import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.ArcaneShapelessRecipeHandler;
 
 import codechicken.lib.gui.GuiDraw;
@@ -34,8 +35,6 @@ import thaumcraft.api.crafting.ShapelessArcaneRecipe;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchItem;
 import thaumcraft.client.lib.UtilsFX;
-
-import static com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper.getPrimalAspectListFromAmounts;
 
 public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler {
 

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.djgiannuzz.thaumcraftneiplugin.ModItems;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -33,6 +34,8 @@ import thaumcraft.api.crafting.ShapelessArcaneRecipe;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchItem;
 import thaumcraft.client.lib.UtilsFX;
+
+import static com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper.getPrimalAspectListFromAmounts;
 
 public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler {
 
@@ -95,6 +98,7 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
         ArcaneShapelessCachedRecipe recipe = (ArcaneShapelessCachedRecipe) arecipes.get(recipeIndex);
         if (recipe.shouldShowRecipe) {
             super.drawBackground(recipeIndex);
+            this.drawAspects(recipeIndex);
             return;
         }
 
@@ -110,6 +114,23 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
         GL11.glPopMatrix();
     }
 
+    public void drawAspects(int recipe) {
+        int[] amounts = this.aspectsAmount.get(recipe);
+        AspectList aspects = getPrimalAspectListFromAmounts(amounts);
+
+        int baseX = 36;
+        int baseY = 115;
+        int count = 0;
+        int columns = aspects.size();
+        int xOffset = (100 - columns * 20) / 2;
+
+        for (int column = 0; column < columns; column++) {
+            Aspect aspect = aspects.getAspectsSortedAmount()[count++];
+            int posX = baseX + column * 18 + xOffset;
+            UtilsFX.drawTag(posX, baseY, aspect, 0, 0, GuiDraw.gui.getZLevel());
+        }
+    }
+
     @Override
     public List<PositionedStack> getIngredientStacksForOverlay(int recipeIndex) {
         CachedRecipe recipe = arecipes.get(recipeIndex);
@@ -121,9 +142,7 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
     @Override
     public void drawExtras(int recipeIndex) {
         ArcaneShapelessCachedRecipe recipe = (ArcaneShapelessCachedRecipe) arecipes.get(recipeIndex);
-        if (recipe.shouldShowRecipe) {
-            super.drawExtras(recipeIndex);
-        } else {
+        if (!recipe.shouldShowRecipe) {
             String textToDraw = I18n.format("tcneiadditions.research.missing");
             int y = 28;
             for (Object text : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(textToDraw, 162)) {
@@ -194,7 +213,7 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
             this.aspects = recipe.getAspects();
             this.shouldShowRecipe = shouldShowRecipe;
             this.researchItem = ResearchCategories.getResearch(recipe.getResearch());
-            NEIHelper.addAspectsToIngredients(this.aspects, this.ingredients, 0);
+            this.addAspectsToIngredients(aspects);
         }
 
         public AspectList getAspectList() {
@@ -263,6 +282,23 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
                 return this.aspects.aspects.containsKey(aspect);
             }
             return super.contains(ingredients, ingredient);
+        }
+
+        protected void addAspectsToIngredients(AspectList aspects) {
+
+            int baseX = 36;
+            int baseY = 115;
+            int count = 0;
+            int columns = aspects.size();
+            int xOffset = (100 - columns * 20) / 2;
+
+            for (int column = 0; column < columns; column++) {
+                Aspect aspect = aspects.getAspectsSortedAmount()[count++];
+                int posX = baseX + column * 18 + xOffset;
+                ItemStack stack = new ItemStack(ModItems.itemAspect, aspects.getAmount(aspect), 1);
+                ItemAspect.setAspect(stack, aspect);
+                this.ingredients.add(new PositionedStack(stack, posX, baseY, false));
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed bookmarks not displaying properly due to some weird ways of doing stuff in tcneiadditions, now bookmarks display the correct aspect amount.

One small caveat is that if the game crashes or forcibly closes you lose just your aspects in the bookmarks page. I'm not sure what is going on with that, but that was already happening before I made changes.

(Ignore the commit saying one-line fix, I was young and Naive then)

OLD:
![image](https://user-images.githubusercontent.com/42074409/236696907-85c6efb7-24ff-4926-ac11-bfe9f5bcfd48.png)

NEW:
![image](https://user-images.githubusercontent.com/42074409/236697006-1d3be2df-eefe-4361-8181-dbf905e4cf43.png)
