### PR TITLE
Move 'open recipes' button

### DIFF
--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
@@ -43,6 +43,11 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
     private final int aspectsPerRow = 3;
 
     @Override
+    public void loadTransferRects() {
+        TCUtil.loadTransferRects(this);
+    }
+
+    @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
         if (outputId.equals(this.getOverlayIdentifier())) {
             for (Object o : ThaumcraftApi.getCraftingRecipes()) {
@@ -163,6 +168,8 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
                 y += 11;
             }
         }
+
+        TCUtil.drawSeeAllRecipesLabel();
     }
 
     @Override

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -44,6 +44,11 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
     private final int aspectsPerRow = 7;
 
     @Override
+    public void loadTransferRects() {
+        TCUtil.loadTransferRects(this);
+    }
+
+    @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
         if (outputId.equals(this.getOverlayIdentifier())) {
             for (Object o : ThaumcraftApi.getCraftingRecipes()) {
@@ -146,6 +151,8 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
                 y += 11;
             }
         }
+
+        TCUtil.drawSeeAllRecipesLabel();
     }
 
     @Override

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
@@ -50,6 +50,11 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
     private int ySizeNormal, ySizeRod, ySizeCap;
 
     @Override
+    public void loadTransferRects() {
+        TCUtil.loadTransferRects(this);
+    }
+
+    @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
         if (outputId.equals(this.getOverlayIdentifier())) {
             for (Object o : ThaumcraftApi.getCraftingRecipes()) {
@@ -314,6 +319,8 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
                 }
             }
         }
+
+        TCUtil.drawSeeAllRecipesLabel();
     }
 
     private class ArcaneShapedCachedRecipe extends ShapedRecipeHandler.CachedShapedRecipe

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
@@ -44,6 +44,11 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
     private int ySize;
 
     @Override
+    public void loadTransferRects() {
+        TCUtil.loadTransferRects(this);
+    }
+
+    @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
         if (outputId.equals(this.getOverlayIdentifier())) {
             for (Object o : ThaumcraftApi.getCraftingRecipes()) {
@@ -170,6 +175,8 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
                 y += 11;
             }
         }
+
+        TCUtil.drawSeeAllRecipesLabel();
     }
 
     private boolean isValidInput(Object input) {

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
@@ -1,5 +1,6 @@
 package ru.timeconqueror.tcneiadditions.util;
 
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -17,7 +19,9 @@ import net.minecraftforge.oredict.OreDictionary;
 import com.djgiannuzz.thaumcraftneiplugin.items.ItemAspect;
 import com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper;
 
+import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.NEIServerUtils;
+import codechicken.nei.recipe.TemplateRecipeHandler;
 import cpw.mods.fml.common.Loader;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.ThaumcraftApiHelper;
@@ -220,5 +224,24 @@ public class TCUtil {
                                         .translateToLocal("tcneiadditions.research.prerequisites.allresearched"));
             }
         }
+    }
+
+    public static void loadTransferRects(TemplateRecipeHandler handler) {
+        int stringLength = GuiDraw.getStringWidth(
+                EnumChatFormatting.BOLD + StatCollector.translateToLocal("tcneiadditions.gui.nei.seeAll"));
+        handler.transferRects.add(
+                new TemplateRecipeHandler.RecipeTransferRect(
+                        new Rectangle(162 - stringLength, 5, stringLength, 9),
+                        handler.getOverlayIdentifier(),
+                        new Object[0]));
+    }
+
+    public static void drawSeeAllRecipesLabel() {
+        GuiDraw.drawStringR(
+                EnumChatFormatting.BOLD + I18n.format("tcneiadditions.gui.nei.seeAll"),
+                162,
+                5,
+                0x404040,
+                false);
     }
 }

--- a/src/main/resources/assets/tcneiadditions/lang/en_US.lang
+++ b/src/main/resources/assets/tcneiadditions/lang/en_US.lang
@@ -15,6 +15,8 @@ tcneiadditions.research.prerequisites.kill=Kill and Scan
 tcneiadditions.research.prerequisites.allresearched=You have done all the required research
 
 
+tcneiadditions.gui.nei.seeAll=See All
+
 tcneiadditions.config.general=General
 
 tcneiadditions.config.general.showLockedRecipes=Show locked recipes


### PR DESCRIPTION
I had to move the button from the second line because of this PR: https://github.com/GTNewHorizons/NotEnoughItems/pull/451


| before | after | reference |
|-----------|--------|------------|
| ![image](https://github.com/GTNewHorizons/TCNEIAdditions/assets/31038811/aad392c4-5b5a-4460-8c97-68cfc3da3317) | ![image](https://github.com/GTNewHorizons/TCNEIAdditions/assets/31038811/e746fdd7-5437-4e54-972f-a95d5177a974) | ![image](https://github.com/GTNewHorizons/TCNEIAdditions/assets/31038811/2755f1fc-701e-49fe-8c64-da1a8f0f4d0e) |
