### PR TITLE
Add color customization via lang file

### DIFF
--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/AspectCombinationHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/AspectCombinationHandler.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.StatCollector;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -23,6 +23,7 @@ import thaumcraft.common.Thaumcraft;
 public class AspectCombinationHandler extends TemplateRecipeHandler {
 
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
+    private TCNAClient tcnaClient = TCNAClient.getInstance();
 
     @Override
     public String getGuiTexture() {
@@ -36,7 +37,7 @@ public class AspectCombinationHandler extends TemplateRecipeHandler {
 
     @Override
     public String getRecipeName() {
-        return I18n.format("tcneiadditions.aspect_combination.title");
+        return StatCollector.translateToLocal("tcneiadditions.aspect_combination.title");
     }
 
     @Override
@@ -75,17 +76,27 @@ public class AspectCombinationHandler extends TemplateRecipeHandler {
         if (cachedRecipe.getIngredients().isEmpty()) {
             int startY = 25;
             GuiDraw.drawStringC(
-                    I18n.format("tc.aspect.primal"),
+                    StatCollector.translateToLocal("tc.aspect.primal"),
                     TCNAClient.NEI_GUI_WIDTH / 2,
                     startY,
-                    TCNAClient.NEI_TEXT_COLOR,
+                    tcnaClient.getColor("tcneiadditions.gui.textColor"),
                     false);
         } else {
             int spaceX = 16;
             int startX = TCNAClient.NEI_GUI_WIDTH / 2 - (16 + (16 + spaceX) * 2) / 2;
             int startY = 6;
-            DrawUtils.drawXYCenteredString("=", startX + 24, startY + 8, TCNAClient.NEI_TEXT_COLOR, false);
-            DrawUtils.drawXYCenteredString("+", startX + 56, startY + 8, TCNAClient.NEI_TEXT_COLOR, false);
+            DrawUtils.drawXYCenteredString(
+                    "=",
+                    startX + 24,
+                    startY + 8,
+                    tcnaClient.getColor("tcneiadditions.gui.textColor"),
+                    false);
+            DrawUtils.drawXYCenteredString(
+                    "+",
+                    startX + 56,
+                    startY + 8,
+                    tcnaClient.getColor("tcneiadditions.gui.textColor"),
+                    false);
         }
     }
 

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/AspectFromItemStackHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/AspectFromItemStackHandler.java
@@ -4,7 +4,6 @@ import static codechicken.lib.gui.GuiDraw.changeTexture;
 import static codechicken.lib.gui.GuiDraw.drawString;
 import static codechicken.lib.gui.GuiDraw.drawTexturedModalRect;
 
-import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -13,6 +12,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
@@ -44,6 +44,7 @@ public class AspectFromItemStackHandler extends TemplateRecipeHandler {
     private static final int STACKS_OVERLAY_START_Y = TCNAClient.NEI_GUI_HEIGHT - STACKS_OVERLAY_HEIGHT;
     private String playerName;
     private int ticks;
+    private TCNAClient tcnaClient = TCNAClient.getInstance();
 
     public AspectFromItemStackHandler() {
         playerName = Minecraft.getMinecraft().getSession().getUsername();
@@ -51,7 +52,7 @@ public class AspectFromItemStackHandler extends TemplateRecipeHandler {
 
     @Override
     public String getRecipeName() {
-        return I18n.format("tcneiadditions.aspect_from_itemstack.title");
+        return StatCollector.translateToLocal("tcneiadditions.aspect_from_itemstack.title");
     }
 
     @Override
@@ -108,7 +109,7 @@ public class AspectFromItemStackHandler extends TemplateRecipeHandler {
                             ThaumcraftHooks.getTotalToLoad()),
                     2,
                     47,
-                    Color.GREEN.getRGB(),
+                    tcnaClient.getColor("tcneiadditions.gui.loadingTextColor"),
                     true);
         }
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNACrucibleRecipeHandler.java
@@ -1,6 +1,5 @@
 package ru.timeconqueror.tcneiadditions.nei;
 
-import java.awt.Color;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
@@ -9,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -25,6 +23,7 @@ import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.recipe.GuiRecipe;
+import ru.timeconqueror.tcneiadditions.client.TCNAClient;
 import ru.timeconqueror.tcneiadditions.util.GuiRecipeHelper;
 import ru.timeconqueror.tcneiadditions.util.TCNAConfig;
 import ru.timeconqueror.tcneiadditions.util.TCUtil;
@@ -41,6 +40,7 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
     private int ySize;
     private final int aspectsPerRow = 3;
+    private TCNAClient tcnaClient = TCNAClient.getInstance();
 
     @Override
     public void loadTransferRects() {
@@ -142,10 +142,10 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
         if (recipe.shouldShowRecipe) {
             super.drawExtras(recipeIndex);
         } else {
-            String textToDraw = I18n.format("tcneiadditions.research.missing");
+            String textToDraw = StatCollector.translateToLocal("tcneiadditions.research.missing");
             int y = 28;
             for (Object text : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(textToDraw, 162)) {
-                GuiDraw.drawStringC((String) text, 82, y, Color.BLACK.getRGB(), false);
+                GuiDraw.drawStringC((String) text, 82, y, tcnaClient.getColor("tcneiadditions.gui.textColor"), false);
                 y += 11;
             }
         }
@@ -164,7 +164,7 @@ public class TCNACrucibleRecipeHandler extends CrucibleRecipeHandler {
             list.add(StatCollector.translateToLocal("tcneiadditions.research.researchName") + ":");
             list.addAll(listResearchString);
             for (String text : list) {
-                GuiDraw.drawStringC(text, 82, y, Color.BLACK.getRGB(), false);
+                GuiDraw.drawStringC(text, 82, y, tcnaClient.getColor("tcneiadditions.gui.researchNameColor"), false);
                 y += 11;
             }
         }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -1,6 +1,5 @@
 package ru.timeconqueror.tcneiadditions.nei;
 
-import java.awt.Color;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
@@ -9,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.util.EnumChatFormatting;
@@ -26,6 +24,7 @@ import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.recipe.GuiRecipe;
+import ru.timeconqueror.tcneiadditions.client.TCNAClient;
 import ru.timeconqueror.tcneiadditions.util.GuiRecipeHelper;
 import ru.timeconqueror.tcneiadditions.util.TCNAConfig;
 import ru.timeconqueror.tcneiadditions.util.TCUtil;
@@ -42,6 +41,7 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
     private int ySize;
     private final int aspectsPerRow = 7;
+    private TCNAClient tcnaClient = TCNAClient.getInstance();
 
     @Override
     public void loadTransferRects() {
@@ -125,10 +125,10 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
         if (recipe.shouldShowRecipe) {
             super.drawExtras(recipeIndex);
         } else {
-            String textToDraw = I18n.format("tcneiadditions.research.missing");
+            String textToDraw = StatCollector.translateToLocal("tcneiadditions.research.missing");
             int y = 28;
             for (Object text : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(textToDraw, 162)) {
-                GuiDraw.drawStringC((String) text, 82, y, Color.BLACK.getRGB(), false);
+                GuiDraw.drawStringC((String) text, 82, y, tcnaClient.getColor("tcneiadditions.gui.textColor"), false);
                 y += 11;
             }
         }
@@ -147,7 +147,7 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
             list.add(StatCollector.translateToLocal("tcneiadditions.research.researchName") + ":");
             list.addAll(listResearchString);
             for (String text : list) {
-                GuiDraw.drawStringC(text, 82, y, Color.BLACK.getRGB(), false);
+                GuiDraw.drawStringC(text, 82, y, tcnaClient.getColor("tcneiadditions.gui.researchNameColor"), false);
                 y += 11;
             }
         }
@@ -182,19 +182,23 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
         if (!recipe.shouldShowRecipe) return;
 
         if (TCNAConfig.showInstabilityNumber) {
-            final int[] colors = { 0x0000AA, 0x5555FF, 0xAA00AA, 0xFFFF55, 0xFFAA00, 0xAA0000 };
             int colorIndex = Math.min(5, recipe.getInstability() / 2);
             String text = StatCollector.translateToLocal("tc.inst") + recipe.getInstability();
             GuiDraw.drawString(
                     text,
                     x + 56 - GuiDraw.fontRenderer.getStringWidth(text) / 2,
                     y + 263,
-                    colors[colorIndex],
+                    tcnaClient.getColor("tcneiadditions.gui.instabilityColor" + colorIndex),
                     false);
         } else {
             int inst = Math.min(5, recipe.getInstability() / 2);
             String text = StatCollector.translateToLocal("tc.inst." + inst);
-            GuiDraw.drawString(text, x + 56 - GuiDraw.fontRenderer.getStringWidth(text) / 2, y + 263, 0xffffff, false);
+            GuiDraw.drawString(
+                    text,
+                    x + 56 - GuiDraw.fontRenderer.getStringWidth(text) / 2,
+                    y + 263,
+                    tcnaClient.getColor("tcneiadditions.gui.instabilityColorOff"),
+                    false);
         }
     }
 

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
@@ -2,7 +2,6 @@ package ru.timeconqueror.tcneiadditions.nei.arcaneworkbench;
 
 import static com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper.getPrimalAspectListFromAmounts;
 
-import java.awt.Color;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
@@ -11,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -48,6 +46,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
 
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
     private int ySizeNormal, ySizeRod, ySizeCap;
+    private TCNAClient tcnaClient = TCNAClient.getInstance();
 
     @Override
     public void loadTransferRects() {
@@ -259,10 +258,10 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
         }
 
         if (!shouldShowRecipe) {
-            String textToDraw = I18n.format("tcneiadditions.research.missing");
+            String textToDraw = StatCollector.translateToLocal("tcneiadditions.research.missing");
             int y = 28;
             for (String text : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(textToDraw, 162)) {
-                GuiDraw.drawStringC(text, 82, y, Color.BLACK.getRGB(), false);
+                GuiDraw.drawStringC(text, 82, y, tcnaClient.getColor("tcneiadditions.gui.textColor"), false);
                 y += 11;
             }
         }
@@ -281,7 +280,12 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
                 list.add(StatCollector.translateToLocal("tcneiadditions.research.researchName") + ":");
                 list.addAll(listResearchString);
                 for (String text : list) {
-                    GuiDraw.drawStringC(text, 82, y, Color.BLACK.getRGB(), false);
+                    GuiDraw.drawStringC(
+                            text,
+                            82,
+                            y,
+                            tcnaClient.getColor("tcneiadditions.gui.researchNameColor"),
+                            false);
                     y += 11;
                 }
             } else {
@@ -297,7 +301,12 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
                     list.add(StatCollector.translateToLocal("tcneiadditions.research.researchName_rod") + ":");
                     list.addAll(listResearchString);
                     for (String text : list) {
-                        GuiDraw.drawStringC(text, 82, y, Color.BLACK.getRGB(), false);
+                        GuiDraw.drawStringC(
+                                text,
+                                82,
+                                y,
+                                tcnaClient.getColor("tcneiadditions.gui.researchNameColor"),
+                                false);
                         y += 11;
                     }
                 }
@@ -313,7 +322,12 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
                     list.add(StatCollector.translateToLocal("tcneiadditions.research.researchName_cap") + ":");
                     list.addAll(listResearchString);
                     for (String text : list) {
-                        GuiDraw.drawStringC(text, 82, y, Color.BLACK.getRGB(), false);
+                        GuiDraw.drawStringC(
+                                text,
+                                82,
+                                y,
+                                tcnaClient.getColor("tcneiadditions.gui.researchNameColor"),
+                                false);
                         y += 11;
                     }
                 }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
@@ -2,7 +2,6 @@ package ru.timeconqueror.tcneiadditions.nei.arcaneworkbench;
 
 import static com.djgiannuzz.thaumcraftneiplugin.nei.NEIHelper.getPrimalAspectListFromAmounts;
 
-import java.awt.Color;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
@@ -11,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -27,6 +25,7 @@ import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.recipe.GuiRecipe;
+import ru.timeconqueror.tcneiadditions.client.TCNAClient;
 import ru.timeconqueror.tcneiadditions.util.GuiRecipeHelper;
 import ru.timeconqueror.tcneiadditions.util.TCNAConfig;
 import ru.timeconqueror.tcneiadditions.util.TCUtil;
@@ -41,6 +40,7 @@ import thaumcraft.client.lib.UtilsFX;
 public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler {
 
     private final String userName = Minecraft.getMinecraft().getSession().getUsername();
+    private TCNAClient tcnaClient = TCNAClient.getInstance();
     private int ySize;
 
     @Override
@@ -149,10 +149,10 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
     public void drawExtras(int recipeIndex) {
         ArcaneShapelessCachedRecipe recipe = (ArcaneShapelessCachedRecipe) arecipes.get(recipeIndex);
         if (!recipe.shouldShowRecipe) {
-            String textToDraw = I18n.format("tcneiadditions.research.missing");
+            String textToDraw = StatCollector.translateToLocal("tcneiadditions.research.missing");
             int y = 28;
             for (Object text : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(textToDraw, 162)) {
-                GuiDraw.drawStringC((String) text, 82, y, Color.BLACK.getRGB(), false);
+                GuiDraw.drawStringC((String) text, 82, y, tcnaClient.getColor("tcneiadditions.gui.textColor"), false);
                 y += 11;
             }
         }
@@ -171,7 +171,7 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
             list.add(StatCollector.translateToLocal("tcneiadditions.research.researchName") + ":");
             list.addAll(listResearchString);
             for (String text : list) {
-                GuiDraw.drawStringC(text, 82, y, Color.BLACK.getRGB(), false);
+                GuiDraw.drawStringC(text, 82, y, tcnaClient.getColor("tcneiadditions.gui.researchNameColor"), false);
                 y += 11;
             }
         }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/proxy/ClientProxy.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/proxy/ClientProxy.java
@@ -19,6 +19,7 @@ public class ClientProxy extends CommonProxy {
     public void preInit(FMLPreInitializationEvent event) {
         TCNAConfig.init(event.getSuggestedConfigurationFile());
         FMLCommonHandler.instance().bus().register(TCNAClient.getInstance());
+        TCNAClient.getInstance().registerResourceReloadListener();
         MinecraftForge.EVENT_BUS.register(new HandlerRemover());
         MinecraftForge.EVENT_BUS.register(new NEIConfig());
         super.preInit(event);

--- a/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/util/TCUtil.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -23,6 +22,7 @@ import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.recipe.TemplateRecipeHandler;
 import cpw.mods.fml.common.Loader;
+import ru.timeconqueror.tcneiadditions.client.TCNAClient;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.ThaumcraftApiHelper;
 import thaumcraft.api.aspects.Aspect;
@@ -34,6 +34,8 @@ import thaumcraft.common.lib.research.ResearchManager;
 import tuhljin.automagy.config.ModResearchItems;
 
 public class TCUtil {
+
+    private static TCNAClient tcnaClient = TCNAClient.getInstance();
 
     public static List<InfusionRecipe> getInfusionRecipes(ItemStack result) {
         List<InfusionRecipe> list = new ArrayList<>();
@@ -238,10 +240,10 @@ public class TCUtil {
 
     public static void drawSeeAllRecipesLabel() {
         GuiDraw.drawStringR(
-                EnumChatFormatting.BOLD + I18n.format("tcneiadditions.gui.nei.seeAll"),
+                EnumChatFormatting.BOLD + StatCollector.translateToLocal("tcneiadditions.gui.nei.seeAll"),
                 162,
                 5,
-                0x404040,
+                tcnaClient.getColor("tcneiadditions.gui.textColor"),
                 false);
     }
 }

--- a/src/main/resources/assets/tcneiadditions/lang/en_US.lang
+++ b/src/main/resources/assets/tcneiadditions/lang/en_US.lang
@@ -14,8 +14,17 @@ tcneiadditions.research.prerequisites.aspect=Scan aspect
 tcneiadditions.research.prerequisites.kill=Kill and Scan
 tcneiadditions.research.prerequisites.allresearched=You have done all the required research
 
-
 tcneiadditions.gui.nei.seeAll=See All
+tcneiadditions.gui.textColor=404040
+tcneiadditions.gui.instabilityColorOff=FFFFFF
+tcneiadditions.gui.instabilityColor0=0000AA
+tcneiadditions.gui.instabilityColor1=5555FF
+tcneiadditions.gui.instabilityColor2=AA00AA
+tcneiadditions.gui.instabilityColor3=FFFF55
+tcneiadditions.gui.instabilityColor4=FFAA00
+tcneiadditions.gui.instabilityColor5=AA0000
+tcneiadditions.gui.researchNameColor=000000
+tcneiadditions.gui.loadingTextColor=00CC00
 
 tcneiadditions.config.general=General
 


### PR DESCRIPTION
This PR adds the following:
- Ability to change text colors by changing the now new hex codes in the lang-file
- Replaces `I18n.format()` with `StatCollector.translateToLocal()` where it makes sense to make code more consistent
- Reduce number of singleton `.instance()` calls by caching the instance inside of the classes where it is needed.

The hex codes for the colors will be read, converted and cached in the `TCNAClient` singleton on resource reload, aka on initial game start when loading resources and when the resource pack changes. 