### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -13,15 +13,6 @@
 		],
 		"credits": "",
 		"logoFile": "",
-		"screenshots": [],
-		"requiredMods": [
-			"Thaumcraft",
-			"thaumcraftneiplugin", "spongemixins@[1.1.0,)"
-		],
-		"dependencies": [
-			"Thaumcraft",
-			"thaumcraftneiplugin", "spongemixins@[1.1.0,)"
-		],
-		"useDependencyInformation": true
+		"screenshots": []
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.