### PR TITLE
fix long standing bug with items with damage value OreDictionary.WILDCARD_VALUE not being rendered correctly in some cases

### DIFF
--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapedHandler.java
@@ -562,7 +562,7 @@ public class ArcaneCraftingShapedHandler extends ArcaneShapedRecipeHandler {
                                 object,
                                 positions[y * width + x][0] + shiftX,
                                 positions[y * width + x][1] + shiftY,
-                                false);
+                                object instanceof ItemStack);
                         stack.setMaxSize(1);
                         this.ingredients.add(stack);
                     }

--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/arcaneworkbench/ArcaneCraftingShapelessHandler.java
@@ -246,7 +246,7 @@ public class ArcaneCraftingShapelessHandler extends ArcaneShapelessRecipeHandler
                                 items.get(x),
                                 positions[x][0] + shiftX,
                                 positions[x][1] + shiftY,
-                                false);
+                                items.get(x) instanceof ItemStack);
                         stack.setMaxSize(1);
                         this.ingredients.add(stack);
                     }


### PR DESCRIPTION
This fixes an issue in ArcaneShapedRecipeHandler/ArcaneShapelessRecipeHandler where it will never generate permutations for items, so when passing an item (e.g. a Thaumcraft shard) with meta 32767, instead of cycling through all Thaumcraft:ItemShard it will instead render minecraft:fire and throw an error as per [codechicken.nei.PositionedStack#85](https://github.com/GTNewHorizons/NotEnoughItems/blob/master/src/main/java/codechicken/nei/PositionedStack.java#L85)