### PR TITLE
Fix floating point error causing misaligned infusion recipes

### DIFF
--- a/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
+++ b/src/main/java/ru/timeconqueror/tcneiadditions/nei/TCNAInfusionRecipeHandler.java
@@ -260,7 +260,7 @@ public class TCNAInfusionRecipeHandler extends InfusionRecipeHandler {
             int y = -35;
             int le = recipe.getComponents().length;
             ArrayList<Point> coords = new ArrayList<>();
-            float pieSlice = (float) (360 / le);
+            float pieSlice = 360f / le;
             float currentRot = -90.0F;
 
             int total;


### PR DESCRIPTION
`float pieSlice = (float) (360 / le);`  
360 is an integer, `le` is also an integer, this will cause division to produce an integer, therefore discarding any decimal before it can be cast to a float, meaning any infusion recipes with a number of ingredients not equal to a factor of 360 (1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 15, 18, 20, 24, 30, 36, 40, 45, 60, 72, 90, 120, 180, 360) will be misaligned (in this extreme case, 26 items, 360/26 = ~13.85 degrees, discarding the decimal portion gives 13 degrees, 13*26 = 338 degrees
![image](https://github.com/user-attachments/assets/4438a7e8-2dc5-4ac3-a3a2-20061b4bc587)

`float pieSlice = 360f / le;`  
360f is a float. A float divided by an integer returns a float. 
